### PR TITLE
Add more locales to the Gaia community builds

### DIFF
--- a/l10n-master/dir-builds.json
+++ b/l10n-master/dir-builds.json
@@ -15,7 +15,27 @@
     "server": "http://hg.mozilla.org/",
     "locales":
     [
-     "pl"
+      "cs",
+      "cy",
+      "de",
+      "el",
+      "eo",
+      "ff",
+      "fr",
+      "fy-NL",
+      "gd",
+      "he",
+      "hu",
+      "it",
+      "ko",
+      "nl",
+      "pa",
+      "pl",
+      "ro",
+      "ru",
+      "sl",
+      "sq",
+      "zh-TW"
      ]
   }
 ]


### PR DESCRIPTION
The list of locales who opted in has been taken on October 11, 2012 from the
following etherpad:

https://l10n.etherpad.mozilla.org/ep/pad/view/community-gaia-list/B6JPPe6zv4
